### PR TITLE
License and editable install

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     "CC-BY-4.0",
     "Other"
   ],
+  "is_package": "n",
   "use_pre_commit": "n",
   "use_conda": "n",
   "use_docker": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,9 +5,9 @@
   "repository_name": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "version": "0.1.0",
   "open_source_license": [
-    "CC-BY-4.0",
     "MIT",
     "GPL-3.0",
+    "CC-BY-4.0",
     "Other"
   ],
   "use_pre_commit": "n",

--- a/{{cookiecutter.repository_name}}/pyproject.toml
+++ b/{{cookiecutter.repository_name}}/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=64.4.0", "wheel", "pip>=22.3"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "my-paper"
@@ -27,6 +27,12 @@ docs = [
     "jupytext",
     "sphinxcontrib-bibtex",
 ]
+
+{%- if cookiecutter.is_package|lower == "n" %}
+# Needed for editable install with no package
+[tool.setuptools]
+packages = []
+{% endif %}
 
 {%- if cookiecutter.use_pre_commit|lower == "y" %}
 [tool.ruff]


### PR DESCRIPTION
- Make editable install work with setuptools by adding
```toml
[tool.setuptools]
packages = []
```
and add a question whether this should be treated as a package or not
- Change default license to MIT